### PR TITLE
2주차

### DIFF
--- a/2주차/BOJ_1039_교환_maiego.java
+++ b/2주차/BOJ_1039_교환_maiego.java
@@ -1,0 +1,59 @@
+import java.util.*;
+
+public class Main {
+	
+	static class Item {
+		String s;
+		int cnt;
+		Item(String a, int b) {
+			s=a; cnt=b;
+		}
+	}
+	
+	static void swap(char[] arr, int i, int j) {
+		char tmp = arr[i];
+		arr[i] = arr[j];
+		arr[j] = tmp;
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		String n = sc.next();
+		int k = sc.nextInt();
+		
+		Deque<Item> q = new ArrayDeque<>();
+		int ans = 0;
+		q.add(new Item(n, 0));
+		int[][] vis = new int[1000001][11];
+		while (!q.isEmpty()) {
+			Item item = q.pop();
+			int x = Integer.parseInt(item.s);
+			if (item.cnt==k) {
+				ans = Math.max(ans, x);
+				continue;
+			}
+			if (++vis[x][item.cnt]>1) continue;
+
+			char[] s = item.s.toCharArray();
+			int sz = s.length;
+			for (int i=1; i<sz; ++i) {
+				if (s[i]!='0') {
+					swap(s, i,0);
+					q.add(new Item(new String(s), item.cnt+1));
+					swap(s, i,0);
+				}
+			}
+			
+			for (int i=1; i<sz; ++i) {
+				for (int j=i+1; j<sz; ++j) {
+					swap(s, i,j);
+					q.add(new Item(new String(s), item.cnt+1));
+					swap(s, i,j);
+				}
+			}
+		}
+		System.out.println(ans==0 ? -1 : ans);
+
+	}
+
+}

--- a/2주차/BOJ_16947_서울지하철_maiego.java
+++ b/2주차/BOJ_16947_서울지하철_maiego.java
@@ -1,0 +1,62 @@
+import java.util.*;
+
+public class Main {
+	static List<Integer> adj[];
+	static int[] onstk, vis;
+	static Deque<Integer> stack = new ArrayDeque<>();
+	
+	static void dfs(int u, int p) {
+		onstk[u] = 1;
+		stack.push(u);
+		for (int v: adj[u]) {
+			if (vis[v]>0 || v==p) continue;
+			if (onstk[v]==1) {
+				while (stack.peek()!=v)
+					vis[stack.pop()]=2;
+				vis[v]=2;
+				return;
+			} else dfs(v, u);
+		}
+		onstk[u] = 0;
+		if (vis[u]==2) return;
+		stack.pop();
+		vis[u] = 1;
+	}
+	
+	static int dfs2(int u, int p) {
+		if (vis[u]==2) return 0;
+		int ret = (int)1e9;
+		for (int v: adj[u]) {
+			if (v==p) continue;
+			ret = Math.min(ret, dfs2(v, u));
+		}
+		return 1+ret;
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		StringBuilder sb = new StringBuilder();
+		
+		int n = sc.nextInt();
+		onstk = new int[n+1];
+		vis = new int[n+1];
+		adj = new List[n+1];
+		for (int i=1; i<=n; ++i)
+			adj[i] = new ArrayList<>();
+		
+		for (int i=0; i<n; ++i) {
+			int a = sc.nextInt();
+			int b = sc.nextInt();
+			adj[a].add(b);
+			adj[b].add(a);
+		}
+		
+		dfs(1, -1);
+		
+		for (int i=1; i<=n; ++i)
+			sb.append(dfs2(i, -1)).append(' ');
+		System.out.println(sb);
+
+	}
+
+}

--- a/2주차/BOJ_1765_닭싸움팀정하기_maiego.java
+++ b/2주차/BOJ_1765_닭싸움팀정하기_maiego.java
@@ -1,0 +1,50 @@
+import java.util.*;
+
+public class Main {
+	static int[] link;
+	
+	static int find(int x) {
+		return x==link[x] ? x : (link[x]=find(link[x]));
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		
+		int n = sc.nextInt();
+		int q = sc.nextInt();
+		link = new int[n+1];
+		for (int i=1; i<=n; ++i)
+			link[i]=i;
+		List<Integer> enemy[] = new List[n+1];
+		for (int i=1; i<=n; ++i)
+			enemy[i] = new ArrayList<>();
+		
+		while (q-->0) {
+			String s = sc.next();
+			int a = sc.nextInt();
+			int b = sc.nextInt();
+			if (s.equals("E")) {
+				enemy[a].add(b);
+				enemy[b].add(a);
+			} else {
+				int x=find(a), y=find(b);
+				link[x]=y;
+			}
+		}
+		
+		for (int i=1; i<=n; ++i) {
+			for (int j=1; j<enemy[i].size(); ++j) {
+				int x=find(enemy[i].get(j)), y=find(enemy[i].get(j-1));
+				link[x]=y;
+			}
+		}
+		
+		int ans=0;
+		for (int i=1; i<=n; ++i)
+			if (link[i] == i) ++ans;
+		
+		System.out.println(ans);
+
+	}
+
+}

--- a/2주차/BOJ_1781_컵라면_maiego.java
+++ b/2주차/BOJ_1781_컵라면_maiego.java
@@ -1,0 +1,44 @@
+import java.util.*;
+
+public class Main {
+	static int[] link;
+
+	static class Item {
+		int deadline, reward;
+		Item (int a, int b) {
+			deadline=a; reward=b;
+		}
+	}
+	
+	static int find(int x) {
+		return x==link[x] ? x : (link[x]=find(link[x]));
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		
+		int n = sc.nextInt();
+		Item[] arr = new Item[n];
+		for (int i=0; i<n; ++i) {
+			int a = sc.nextInt();
+			int b = sc.nextInt();
+			arr[i] = new Item(a, b);
+		}
+		Arrays.sort(arr, (a,b)->b.reward-a.reward);
+		
+		link = new int[n+1];
+		for (int i=1; i<=n; ++i)
+			link[i] = i;
+
+		int ans=0;
+		for (Item item: arr) {
+			int x = find(item.deadline);
+			if (x==0) continue;
+			ans += item.reward;
+			link[x] = x-1;
+		}
+
+		System.out.println(ans);
+	}
+
+}

--- a/2주차/BOJ_2482_색상환_maiego.java
+++ b/2주차/BOJ_2482_색상환_maiego.java
@@ -1,0 +1,37 @@
+import java.util.*;
+
+public class Main {
+	final static int mod = (int)1e9+3;
+	static int n,k;
+	static int[][][] cache = new int[1001][1001][2];
+	static boolean[][][] vis = new boolean[1001][1001][2];
+
+	static int f(int idx, int cnt, int select0) {
+		if (cnt==k) return 1;
+		if (idx>=n) return 0;
+		if (vis[idx][cnt][select0])
+			return cache[idx][cnt][select0];
+		
+		long ret = f(idx+1, cnt, select0);
+		if (idx!=n-1 || select0==0) {
+			ret += f(idx+2, cnt+1, select0);
+			ret %=mod;
+		}
+		
+		vis[idx][cnt][select0] = true;
+		return cache[idx][cnt][select0] = (int)ret;
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		
+		n = sc.nextInt();
+		k = sc.nextInt();
+
+		long ans = f(2,1,1) + f(1,0,0);
+		ans %= mod;
+		System.out.println((int)ans);
+
+	}
+
+}

--- a/2주차/BOJ_9007_카누선수_maiego.java
+++ b/2주차/BOJ_9007_카누선수_maiego.java
@@ -1,0 +1,56 @@
+import java.util.*;
+
+public class Main {
+	static int n,k;
+	static int ans, minDiff;
+	
+	static void upt(int sum) {
+		int diff = Math.abs(sum-k);
+		if (diff<minDiff) {
+			minDiff = diff;
+			ans = sum;
+		} else if (diff==minDiff && sum<ans)
+			ans = sum;
+	}
+
+	public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+		StringBuilder sb = new StringBuilder();
+		
+		int T = sc.nextInt();
+		while (T-->0) {
+            k = sc.nextInt();
+            n = sc.nextInt();
+            
+			int[][] input = new int[4][n];
+			for (int i=0; i<4; ++i)
+				for (int j=0; j<n; ++j)
+					input[i][j] = sc.nextInt();
+			
+			int[] list = new int[n*n];
+			int idx=0;
+			for (int i=0; i<n; ++i)
+				for (int j=0; j<n; ++j)
+					list[idx++] = input[0][i]+input[1][j];
+			Arrays.sort(list);
+			
+			minDiff = (int)1e9;
+			for (int i=0; i<n; ++i)
+				for (int j=0; j<n; ++j) {
+					int sum = input[2][i] + input[3][j];
+
+					int lo=0, hi=n*n-1;
+					while (lo<=hi) {
+						int mid = lo+hi>>1;
+					    if (list[mid]<k-sum) lo=mid+1;
+					    else hi=mid-1;
+					    upt(sum+list[mid]);
+					}
+				}
+			sb.append(ans).append('\n');
+		}
+		System.out.println(sb);
+
+	}
+
+}


### PR DESCRIPTION
## 컵라면
[문제링크](https://www.acmicpc.net/problem/1781) 

### 유파 풀이
 - 컵라면 많이 주는거 순으로 정렬 O(NlogN)
- 데드라인 안에 선택할 수 있으면 선택하는 것이 이득
- 데드라인까지 시간 중 선택안한 시간을 O(logN)에 찾아야 함 -> 유파 공항문제 풀이를 이용

### 우선순위 큐 풀이
- 데드라인 큰 순, 같다면 컵라면 많이 주는 순으로 정렬
- 시간 젤 뒤에서부터 데드라인이 그 시간이면 우선순위 큐에 추가
- 우선순위 큐는 보상값 max힙
- 그 중에서 보상값 젤 큰거를 뽑음 -> 그 시간에 선택하는 것을 찾은 것
- 데드라인 1줄이고 반복 

## 서울 지하철 2호선 
 [문제링크](https://www.acmicpc.net/problem/16947) 
 - cycle 디텍트하고 cycle 경로 구하는 문제
 - SCC와 유사하게 dfs 진입시 stack에 추가하고 나올 때 stack에서 뺌
 - 이웃노드 중 stack에 이미 들어있는 값이 나오면 cycle의 시작점을 찾은 것
 -  dfs(u) 에서 u의 이웃 v가 stack에 이미 들어있다면 싸이클의 경로는 v->u임.
 - stack을 팝하면서 사이클을 이루는 노드들을 flag 바꿈
 - cycle 이루는 노드들까지의 거리를 dfs로 구현

## 닭싸움 팀 정하기
[문제링크](https://www.acmicpc.net/problem/1765)
- 적의 적은 친구다 -> enemy[i] = List<>(); 일 때  enemy[i]의 원소들은 다 같은 편이된다.
- 유파로 F일 때 합하고 E인건 기록했다가 enemy[i] 들마다 원소들끼리 합하면 된다.
- 종만북 에디터 전쟁 문제와 똑같

## 카누선수
[문제링크](https://www.acmicpc.net/problem/9007) 
- 두 반을 먼저 돌면서 가능한 합을 N^2 배열에 구한다(ArrayList를 쓰면 시간초과가 난다!)
- 다른 두반을 돌면서 만든 합을 이용해(laterSum)
- sum[lo] <=k-laterSum < sum[hi] 인 lo+1 == hi 인 구간을 이분탐색으로 찾는다. O(n^2 log n)
- sum[lo]+laterSum 과 sum[hi]+laterSum으로 답을 갱신한다
 - 시간복잡도 n^2 logn

## 색상환
[문제링크](https://www.acmicpc.net/problem/2482) 

### 탑다운 풀이
- 첫번째 값을 선택했는지를 나타내는 flag 변수 추가 f(idx, cnt, flag) 로 구현
- idx==n-1 일 때 flag 켜져있으면 안고름
- 골랐다면 f(idx+2, cnt+1, flag)
- 안골랐다면 f(idx+1, cnt, flag)
- 메모이제이션 필수
- main에서 f(1,1,1) + f(1,0,0) 으로 답 구함

### 바텀업 풀이
- dp[idx][cnt] 를 구함
- dp[idx][cnt] = dp[idx-2][cnt-1] + dp[idx-1][cnt]
- 초기화는 dp[i][0] = 1, dp[i][1] = i;
- 마지막 n-1번째와 0번째는 겹칠 수 있기 때문에 마지막 수 고르는 경우는 dp[n-4][k-1] 이고 안고르면 dp[n-2][k]
- dp[n-4][k-1]은 0부터 n-4까지 중 k-1개를 고르는 경우의 수인데 1부터 n-3까지 중 k-1개를 고르는 경우의 수와 같으므로 dp[n-4][k-1]를 사용
	 
## 교환
[문제링크](https://www.acmicpc.net/problem/1039) 
- 숫자를 char[]로 바꾸고 BFS 돌리면 됨
- 큐에서 꺼내서 가장 왼쪽 수를 바꾸는 루프, 첫번째 아닌 인덱스끼리 바꾸는 루프로 구현