### PR TITLE
2주차

### DIFF
--- a/2주차/BOJ_16947_서울지하철2호선_ssu.py
+++ b/2주차/BOJ_16947_서울지하철2호선_ssu.py
@@ -1,0 +1,62 @@
+import sys
+
+class Graph:
+    def __init__(self,N):
+        self.N = N
+        self.con = [
+            []
+            for _ in range(N+1)
+        ]
+        
+    def add_edge(self,x,y,bidirect=True):
+        pass
+    
+    def is_x_y_con(self,x,y):
+        pass
+    
+    def get_con_by_x(self,x):
+        pass
+    
+    
+class adjList(Graph):
+    def __init__(self,N):
+        super().__init__(N)
+    
+    def add_edge(self, x, y, bidirect=True):
+        self.con[x].append(y)
+        if bidirect:
+            self.con[y].append(x)
+            
+    def is_x_y_con(self, x, y):
+        return y in self.con[x]
+    
+    def get_con_by_x(self, x):
+        return self.con[x]
+
+
+def findCircle():
+    global visited
+    visited = [0]*(N+1)
+    dfs(1,1)
+    # for i in range(1,N+1):
+    
+def dfs(start,current):
+    visited[current]=1
+    if current in adj.get_con_by_x(start):
+        print(visited)
+        return
+    for e in adj.get_con_by_x(current):
+        if not visited[e]:
+            dfs(start,e)
+si = sys.stdin.readline
+
+N = int(si().rstrip())
+
+adj = adjList(N)
+
+visited = [0]*(N+1)
+for _ in range(N):
+    x,y = map(int,si().rstrip().split())
+    adj.add_edge(x,y)
+
+findCircle()

--- a/2주차/BOJ_1781_컵라면_ssu.java
+++ b/2주차/BOJ_1781_컵라면_ssu.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        Quest[] questarr = new Quest[N];
+        for(int i=0;i<N;i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int dL = Integer.parseInt(st.nextToken());
+            int rW = Integer.parseInt(st.nextToken());
+            questarr[i] = new Quest(dL,rW);
+        }
+
+        System.out.println(getMaxmiumReward(questarr));
+    }
+
+    public static int getMaxmiumReward(Quest[] questarr){
+        int result = 0;
+        Arrays.sort(questarr);
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+        for(int i=0,size=questarr.length;i<size;i++){
+            if(questarr[i].deadLine > pq.size()){
+                pq.offer(questarr[i].reward);
+            }
+            else if(questarr[i].deadLine == pq.size()){
+                if(pq.peek()< questarr[i].reward){
+                    pq.poll();
+                    pq.offer(questarr[i].reward);
+                }
+            }
+        }
+
+        while(!pq.isEmpty()){
+            result += pq.poll();
+        }
+        return result;
+    }
+    static class Quest implements Comparable<Quest> {
+        int deadLine;
+        int reward;
+
+        public Quest(int deadLine,int reward){
+            this.deadLine = deadLine;
+            this.reward = reward;
+        }
+
+        @Override
+        public int compareTo(Quest o) {
+            return this.deadLine!=o.deadLine ? this.deadLine-o.deadLine : -(this.reward - o.reward);
+        }
+    }
+}

--- a/2주차/BOJ_2482_색상환_ssu.java
+++ b/2주차/BOJ_2482_색상환_ssu.java
@@ -1,0 +1,25 @@
+import java.util.Scanner;
+
+public class Main {
+    static final int moduler = 1000000003;
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int N = sc.nextInt();
+        int K = sc.nextInt();
+
+        int[][] dpTable = new int[N+1][N+1];
+        for(int i=0;i<=N;i++){
+            dpTable[i][0] = 1;
+            dpTable[i][1] = i;
+        }
+
+        for(int i=2;i<=N;i++){
+            for(int j=2;j<=K;j++){
+                dpTable[i][j] = (dpTable[i-2][j-1]+ dpTable[i-1][j])%moduler;
+            }
+        }
+
+        System.out.println((dpTable[N-1][K]+dpTable[N-3][K-1])%moduler);
+    }
+}

--- a/2주차/BOJ_9007_카누선수_ssu.java
+++ b/2주차/BOJ_9007_카누선수_ssu.java
@@ -1,0 +1,75 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+        while(T-->0){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int k = Integer.parseInt(st.nextToken());
+            int n = Integer.parseInt(st.nextToken());
+            int[][] students= new int[4][n];
+            for(int i=0,size=students.length;i<size;i++){
+                st = new StringTokenizer(br.readLine());
+                for(int j=0;j<n;j++){
+                    students[i][j] = Integer.parseInt(st.nextToken());
+                }
+            }
+
+            int[] comb1 = new int[n*n];
+            int[] comb2 = new int[n*n];
+            int idx=0;
+            for(int i=0;i<n;i++){
+                for(int j=0;j<n;j++){
+                    comb1[idx] = students[0][i] + students[1][j];
+                    comb2[idx++] = students[2][i] + students[3][j];
+                }
+            }
+
+            Arrays.sort(comb1);
+            Arrays.sort(comb2);
+
+            int lP = 0;
+            int rP = idx-1;
+
+            int diff = (int)1e9;
+            int result = (int)1e9;
+
+            while(lP<idx && rP>=0){
+                int current = Math.abs(comb1[lP]+comb2[rP]-k);
+                if(current<diff){
+                    diff = current;
+                    result = comb1[lP] + comb2[rP];
+                }
+                else if(current==diff){
+                    if(result > comb1[lP] + comb2[rP]){
+                        result = comb1[lP] + comb2[rP];
+                    }
+                }
+
+                if(comb1[lP] + comb2[rP]>k){
+                    --rP;
+                }
+                else if(comb1[lP] + comb2[rP] <k){
+                    lP++;
+                }
+                else{
+                    break;
+                }
+            }
+
+            if(lP<idx && rP>=0){
+                if(Math.abs(comb1[lP]+comb2[rP]-k)>diff){
+                    diff = Math.abs(comb1[lP]+comb2[rP]-k);
+                    result = comb1[lP] + comb2[rP];
+                }
+            }
+            sb.append(result).append("\n");
+        }
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
### BOJ 1781 [컵라면](https://www.acmicpc.net/problem/1781)
- 그리디하게 접근
- 데드라인이 빠를 수록, 데드라인이 같다면 컵라면을 많이 받을 수 있도록
- 처음에 실수한 사항 : 매초 데드라인인 문제가 있다고 생각하고 품
- 즉,데드라인까지 풀 수 있는 문제를 최대한으로 풀어야한다.
- minHeap을 이용해서, Heap에 담긴 개수(푼 문제수)와 현재 탐색할 문제의 데드라인을 비교
- 데드라인보다 푼 문제수가 적다면 일단 푸는 셈 치고, 같을 때는 가장 적게 받은 컵라면수와 현재 문제의 컵라면수를 비교해서 갱신

### BOJ 2482 [색상환](https://www.acmicpc.net/problem/2482)
- 단순히 NCK를 구한다면, 최악의 경우인 1000C500은 시간초과
- 인접한 색상만 칠하지 않으면 되기 때문에, 현재 색상칸 입장에서 칠할 건지, 안 칠할 건지를 생각해봄
- DP[n][k] : n개의 서로다른 색(색 상환에 존재하는) 중 k개를 칠하는 경우의 수
- dp[i][j] : 현재 보는 색상칸(i), 현재까지 선택된 색상의 수(j)
- 현재칸을 칠할거라면, 직전칸도 칠하면 안되므로 dp[i-2][j-1]
- 현재칸을 안칠한다면, 직전칸까지 j개를 칠한 수와 같음 dp[i-1][j]
- 원형이기 때문에 마지막 n번칸을 칠한다면 n-1,1을 모두 고려해야함.
- dp[n][k] = dp[n-1][k] + dp[n-3][k-1]
- (A+B)%C != A%C+B%C

### BOJ 9007 [카누선수](https://www.acmicpc.net/problem/9007)
- 단순히 모든 경우를 확인하면 N^4으로 시간초과
- 어차피 각 반에서 1명씩 뽑아서 4명을 만드는 것이므로, 3명 1명, 2명 2명 나눠서 뽑은 뒤에 4명을 만들 수 있는지 찾으면 된다.
- 단, 2명 2명을 뽑고 그대로 비교하면 똑같이 N^4가 되기 때문에, 보트의 특정값이 될 수 있는 케이스를 빠르게 찾아야 함.
- 두 합의 배열을 정렬을 시킨뒤, 투포인터를 양끝에 위치시킨 뒤 합과 특정값을 비교하면서 이동
- 작으면 앞쪽의 포인터를 뒤로, 크다면 뒤쪽의 포인터를 앞으로 이동
- while-else가 없기 때문에, k/2 k/2가 되어 탈출했을 때도 갱신

### BOJ 16947 [서울지하철2호선](https://www.acmicpc.net/problem/16947)
- 인접 리스트, xy 노드의 연결 여부, x에 연결된 노드를 구현하였으나
- 순환선에 속해 있는지를 어떻게 판단할지 감이 안옴
- DFS를 쓸 경우 이미 방문 처리를 해버리면, 처음 출발한 노드를 도달할 수 있는지 알 수가 없다?

### BOJ 1765 [닭싸움 팀 정하기](https://www.acmicpc.net/problem/1765)
- 이 문제에서 "나"로 표현된 것은 모든 학생의 입장에서 생각해야 하는 요구사항인가?
- 문제를 잘 이해하지 못했음