### PR TITLE
2주차

### DIFF
--- a/2주차/BOJ_1039_교환_jhyun.java
+++ b/2주차/BOJ_1039_교환_jhyun.java
@@ -1,0 +1,52 @@
+import java.util.*;
+import java.io.*;
+/*
+모든 경우를 탐색하는 경우의 수 6^10 = 6천만
+재귀로 탐색한다면 스택 제한(128)에 걸릴 수 있음
+* */
+public class Main {
+  static final int INF = 1_000_001;
+  static int N, K, MAX = 1;
+  static Queue<int[]> q = new LinkedList<>();
+  static boolean[][] visit;
+  static int bfs(){
+    visit = new boolean[INF][K + 1];
+    q.add(new int[]{N, 0});
+    visit[N][0] = true;
+    int answer = -1;
+    while(!q.isEmpty()){
+      int[] tmp = q.poll();
+      int cur = tmp[0];
+      int swap = tmp[1];
+      if(swap == K){
+        answer = Math.max(answer, cur);
+      }
+      for(int i = MAX; i > 0; i /= 10){
+        if(i > cur) continue;
+        for(int j = i / 10; j > 0; j /= 10){
+          int d1 = cur / i % 10, d2 = cur / j % 10;
+          int remain = cur - (d1 * i + d2 * j),
+            next = d1 * j + d2 * i + remain;
+          if(next < MAX) continue;
+          if(swap < K && visit[next][swap + 1] == false){
+            q.add(new int[]{next, swap + 1});
+            visit[next][swap + 1] = true;
+          }
+        }
+      }
+    }
+    return answer;
+  }
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    N = Integer.parseInt(st.nextToken());
+    K = Integer.parseInt(st.nextToken());
+    int num = N;
+    while(num >= 10){
+      MAX *= 10;
+      num /= 10;
+    }
+    System.out.println(bfs());
+  }
+}

--- a/2주차/BOJ_16947_서울지하철2호선_jhyun.java
+++ b/2주차/BOJ_16947_서울지하철2호선_jhyun.java
@@ -1,0 +1,75 @@
+import java.util.*;
+import java.io.*;
+public class Main {
+  static int N;
+  static boolean hasCycle = false;
+  static boolean[] visit, cycle;
+  static int[] pre, dist;
+  static Set<Integer> graph[];
+  static void findCycle(int cur){
+    visit[cur] = true;
+    for(Integer next: graph[cur]){
+      if(hasCycle) return;
+      if(visit[next]){
+        if(next != pre[cur]){
+          cycle[cur] = true;
+          hasCycle = true;
+          while(cur != next){
+            cycle[pre[cur]] = true;
+            cur = pre[cur];
+          }
+          return;
+        }
+      }
+      else{
+        pre[next] = cur;
+        findCycle(next);
+      }
+    }
+  }
+  static void bfs(){
+    Queue<Integer> q = new LinkedList<>();
+    for(int i = 1; i <= N; i++){
+      if(cycle[i]){
+        visit[i] = true;
+        q.add(i);
+      }
+    }
+    while(!q.isEmpty()){
+      int cur = q.poll();
+      for(Integer next: graph[cur]){
+        if(visit[next]) continue;
+        visit[next] = true;
+        dist[next] = dist[cur] + 1;
+        q.add(next);
+      }
+    }
+  }
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    N = Integer.parseInt(st.nextToken());
+    int s, e;
+    graph = new Set[N + 1];
+    visit = new boolean[N + 1];
+    cycle = new boolean[N + 1];
+    pre = new int[N + 1];
+    dist = new int[N + 1];
+    for(int i = 0; i <= N; i++){
+      graph[i] = new HashSet<>();
+    }
+    for(int i = 0; i < N; i++){
+      st = new StringTokenizer(br.readLine());
+      s = Integer.parseInt(st.nextToken());
+      e = Integer.parseInt(st.nextToken());
+      graph[s].add(e);
+      graph[e].add(s);
+    }
+    findCycle(1);
+    visit = new boolean[N + 1];
+    bfs();
+    for(int i = 1; i <= N; i++){
+      System.out.printf("%d ", dist[i]);
+    }
+  }
+}

--- a/2주차/BOJ_1765_닭싸움팀정하기_jhyun.java
+++ b/2주차/BOJ_1765_닭싸움팀정하기_jhyun.java
@@ -1,0 +1,92 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+  static int N, M, from, to;
+  static List<Integer> friends[], enemy[];
+  static int[] parents;
+  static boolean[] visit;
+  static int answer = 0;
+  static void dfs(int pre, int cur, int depth){
+    if(depth == 2){
+      friends[cur].add(pre);
+      friends[pre].add(cur);
+      return;
+    }
+    visit[cur] = true;
+    for(Integer next: enemy[cur]){
+      if(visit[next] == false){
+        dfs(pre, next, depth + 1);
+      }
+    }
+    visit[cur] = false;
+  }
+  static int getParent(int x){
+    if(parents[x] < 0){
+      return x;
+    }
+    parents[x] = getParent(parents[x]);
+    return parents[x];
+  }
+  static void union(int a, int b){
+    a = getParent(a);
+    b = getParent(b);
+    if(a < b){
+      parents[b] = a;
+    }
+    else{
+      parents[a] = b;
+    }
+  }
+  static boolean makeTeam(int cur){
+    if(visit[cur]) return false;
+    visit[cur] = true;
+    for(Integer next: friends[cur]){
+      if(getParent(cur) != getParent(next)){
+        union(cur, next);
+      }
+      makeTeam(next);
+    }
+    return true;
+  }
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    N = Integer.parseInt(st.nextToken());
+    M = Integer.parseInt(br.readLine());
+    friends = new List[N + 1];
+    enemy = new List[N + 1];
+    parents = new int[N + 1];
+    visit = new boolean[N + 1];
+    for(int i = 0; i <= N; i++){
+      friends[i] = new ArrayList<>();
+      enemy[i] = new ArrayList<>();
+      parents[i] = -1;
+    }
+    for(int i = 0; i < M; i++){
+      st = new StringTokenizer(br.readLine());
+      String order = st.nextToken();
+      from = Integer.parseInt(st.nextToken());
+      to = Integer.parseInt(st.nextToken());
+      if(order.equals("F")){
+        friends[from].add(to);
+        friends[to].add(from);
+      }
+      else{
+        enemy[from].add(to);
+        enemy[to].add(from);
+      }
+    }
+    //원수의 원수 관계에서 친구 찾기
+    for(int i = 1; i <= N; i++){
+      dfs(i, i, 0);
+    }
+    visit = new boolean[N + 1];
+    //친구 관계에서 유니온
+    for(int i = 1; i <= N; i++){
+      if(makeTeam(i)){
+        answer++;
+      }
+    }
+    System.out.println(answer);
+  }
+}

--- a/2주차/BOJ_1781_컵라면_jhyun.java
+++ b/2주차/BOJ_1781_컵라면_jhyun.java
@@ -1,0 +1,44 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+  public static void main(String[] args) throws  IOException{
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    int n = Integer.parseInt(br.readLine());
+
+    Map<Integer, List<Integer>> map = new HashMap<>();
+    StringTokenizer st;
+    for(int i=0; i<n; i++) {
+      st = new StringTokenizer(br.readLine());
+      int d = Integer.parseInt(st.nextToken());
+      int e = Integer.parseInt(st.nextToken());
+
+      if(map.containsKey(d)) {
+        map.get(d).add(e);
+      }else {
+        List<Integer> list = new ArrayList<>();
+        list.add(e);
+        map.put(d, list);
+      }
+    }
+
+    List<Integer> keySet = new ArrayList<>(map.keySet());
+    Collections.sort(keySet);
+
+    Queue<Integer> pq = new PriorityQueue<>();
+    for(int deadline : keySet) {
+      for(int num : map.get(deadline)) {
+        pq.add(num);
+        while(pq.size()>deadline) {
+          pq.poll();
+        }
+      }
+    }
+    int total=0;
+    while(!pq.isEmpty()) {
+      total+= pq.poll();
+    }
+    System.out.println(total);
+  }
+}

--- a/2주차/BOJ_9007_카누선수_jhyun.java
+++ b/2주차/BOJ_9007_카누선수_jhyun.java
@@ -1,0 +1,73 @@
+import java.util.*;
+import java.io.*;
+/*
+모든 경우를 탐색 = 1000C4 -> TLE
+N^2으로 두 파트로 나눠 합을 구한 후 다시 N^2으로 더함 -> 2 * N^2
+1트: 왜 시간초과? => N^4으로 풀이한거였음..
+* */
+public class Main {
+  static int TC, N, K;
+  static int[][] arr = new int[4][1001];
+  static int[] sumA;
+  static int[] sumB;
+  static int ans, diff;
+  //K에 가까운 값, 일치한다면 K보다 작은 값을 고름
+  static int binSearch(int sum){
+    int s = 0, e = sumB.length - 1, mid, calc;
+    while(s <= e){
+      mid = (s + e) / 2;
+      calc = K - (sumB[mid] + sum);
+      if(diff > Math.abs(calc)){
+        diff = Math.abs(calc);
+        ans = sumB[mid] + sum;
+      }
+      else if(diff == Math.abs(calc) && calc > 0){
+        ans = sumB[mid] + sum;
+      }
+
+      if(calc < 0){
+        e = mid - 1;
+      }
+      else if(calc > 0){
+        s = mid + 1;
+      }
+      else{
+        ans = sumB[mid] + sum;
+        return sumB[mid] + sum;
+      }
+    }
+    return ans;
+  }
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    TC = Integer.parseInt(st.nextToken());
+    while(TC-- > 0){
+      ans = 0;
+      diff = Integer.MAX_VALUE;
+      st = new StringTokenizer(br.readLine());
+      K = Integer.parseInt(st.nextToken());
+      N = Integer.parseInt(st.nextToken());
+      sumA = new int[N * N];
+      sumB = new int[N * N];
+      for(int i = 0; i < 4; i++){
+        st = new StringTokenizer(br.readLine());
+        for(int j = 0; j < N; j++){
+          arr[i][j] = Integer.parseInt(st.nextToken());
+        }
+      }
+      for(int i = 0; i < N; i++){
+        for(int j = 0; j < N; j++){
+          sumA[i * N + j] = arr[0][i] + arr[1][j];
+          sumB[i * N + j] = arr[2][i] + arr[3][j];
+        }
+      }
+      Arrays.sort(sumA);
+      Arrays.sort(sumB);
+      for(int i = 0; i < N * N; i++){
+        binSearch(sumA[i]);
+      }
+      System.out.println(ans);
+    }
+  }
+}


### PR DESCRIPTION
## 서울지하철2호선
- 사이클을 찾는 방법을 헷갈렸음. 크루스칼에 쓰이는 유니온 방식은 낮은 번호의 정점을 기준으로 합치는 방법인데, 이 문제에선 적용할 수 없었다.
- 먼저, 사이클을 정의해야 하는데, 이전에 방문했던 정점 배열을 저장하는 배열로 간선의 다음 노드가 이미 방문했던 노드라면 사이클임을 표시하여 사이클을 이루는 정점들로부터 BFS를 수행함
## 카누 선수
- 나이브하게 풀면 N^4의 복잡도로 시간 초과가 발생한다.
- 문제 요구사항은 K에 가까운 네 배열의 원소 합이므로, sumA[N*N] = a1[1..N] + a2[1..N] 와 같은 형태로 합 배열 두 개를 구성함 (N^2)
- K에 가까운 값을 찾기 위해 정렬하여 이분탐색을 사용한다면 nlogn에 구할 수 있으며. 이 과정에서 K와 차이의 절댓값을 기록하여 정답을 구할 수 있다.
## 닭싸움 팀 정하기
알고 보면 쉬웠는데 유니온 파인드를 적용하는게 익숙치 않아 시간이 오래 걸렸다.
1. 원수의 원수는 친구이므로, dfs를 돌면서 깊이가  2라면 친구 관계 그래프에 추가
2. 문제의 조건 중 친구 관계라면 반드시 팀을 이뤄야 하니까 전체 친구를 돌면서, 유니온 파인드로 친구 관계인 집합을 구성, 집합의 개수를 카운트하면 답을 얻을 수 있다.
## 교환
- 모든 경우를 탐색하는건 너무 많다. 상태 공간 트리를 정의하여 BFS로 탐색하면 최소 횟수를 구할 수 있음
- 정점은 숫자를 교환한 상태이며, 재방문 방지를 위해 boolean 배열을 사용함
- 탐색에서 주의할 점은 조건을 지켜야 함. 0이 맨 앞으로 오는 경우는 만들어 질 수 없기 때문이다.
## 컵라면
- 데드라인안에 가장 많은 컵라면을 주는 문제들을 먼저 풀어야 하는걸 직관으로 알 수 있었다. 따라서 정렬하여 가장 많이 주는 문제부터 하나씩 할당하려 함.
- 그런데, 선형 탐색으로 boolean 배열에 할당하려 하니까 시초가 발생하여 정답을 참고함.
- 이 풀이에선 그리디하게 접근하여 가장 적게 컵라면을 주는 문제부터 우큐에 넣어 데드라인을 초과하면 하나씩 꺼냈음
## 색상환
너무 어렵다. 정답을 봐도 감을 잘 못잡겠음..