### PR TITLE
3주차

### DIFF
--- a/3주차/BOJ_11725_트리의부모찾기_maiego.java
+++ b/3주차/BOJ_11725_트리의부모찾기_maiego.java
@@ -1,0 +1,41 @@
+import java.util.*;
+
+public class Main {
+	static int n;
+	static List<Integer> adj[];
+	static int[] ans;
+	
+	static void dfs(int u, int p) {
+		for (int v: adj[u]) {
+			if (v==p) continue;
+			ans[v]=u;
+			dfs(v,u);
+		}
+
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		StringBuilder sb = new StringBuilder();
+
+		n = sc.nextInt();
+		
+		ans = new int[n+1];
+		adj = new List[n+1];
+		for (int i=1; i<=n; ++i)
+			adj[i] = new ArrayList<>();
+		
+		for (int i=0; i<n-1; ++i) {
+			int a = sc.nextInt();
+			int b = sc.nextInt();
+			adj[a].add(b);
+			adj[b].add(a);
+		}
+		dfs(1,-1);
+		
+		for (int i=2; i<=n; ++i)
+			sb.append(ans[i]).append('\n');
+		System.out.println(sb);
+	}
+
+}

--- a/3주차/BOJ_14889_스타트와링크_maiego.java
+++ b/3주차/BOJ_14889_스타트와링크_maiego.java
@@ -1,0 +1,33 @@
+import java.util.*;
+
+public class Main {
+    static int n;
+    static int[][] scores;
+
+    static int f(int x) {
+        int ret = 0;
+        for (int i=0; i<n; ++i)
+            for (int j=0; j<n; ++j)
+                if ((x&1<<i) >0 && (x&1<<j) >0)
+                    ret += scores[i][j];
+        return ret;
+    }
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        n = sc.nextInt();
+        scores = new int[n][n];
+        for (int i=0; i<n; ++i)
+            for (int j=0; j<n; ++j)
+                scores[i][j] = sc.nextInt();
+
+        int ans = (int)1e9;
+        for (int i=0; i<(1<<n); ++i) {
+            if (Integer.bitCount(i)!=n/2) continue;
+            ans = Math.min(ans, Math.abs(f(i) - f(~i)));
+        }
+        System.out.println(ans);
+    }
+    
+}

--- a/3주차/BOJ_2252_줄세우기_maiego.java
+++ b/3주차/BOJ_2252_줄세우기_maiego.java
@@ -1,0 +1,41 @@
+import java.util.*;
+
+public class Main {
+	static int n;
+	static List<Integer> adj[];
+	static boolean[] vis;
+	static List<Integer> list = new ArrayList<>();
+	
+	static void dfs(int u) {
+		vis[u] = true;
+		for (int v: adj[u]) {
+			if (vis[v]) continue;
+			dfs(v);
+		}
+		list.add(u);
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		n = sc.nextInt();
+		
+		vis = new boolean[n+1];
+		adj = new List[n+1];
+		for (int i=1; i<=n; ++i)
+			adj[i] = new ArrayList<>();
+
+		int m = sc.nextInt();
+		while (m-->0) {
+			int a = sc.nextInt();
+			int b = sc.nextInt();
+			adj[a].add(b);
+		}
+		for (int i=1; i<=n; ++i)
+			if (!vis[i]) dfs(i);
+		
+		Collections.reverse(list);
+		for (int x: list)
+			System.out.print(x + " ");
+	}
+
+}

--- a/3주차/BOJ_2805_나무자르기_maiego.java
+++ b/3주차/BOJ_2805_나무자르기_maiego.java
@@ -1,0 +1,32 @@
+import java.util.*;
+
+public class Main { 
+    static int n,k;
+    static int[] arr;
+
+    static boolean pos(int x) {
+        long acc=0;
+        for (int i=0; i<n; ++i)
+            acc += Math.max(arr[i]-x, 0);
+        return acc>=k;
+    }
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        n = sc.nextInt();
+        k = sc.nextInt();
+        arr = new int[n];
+        for (int i=0; i<n; ++i)
+            arr[i] = sc.nextInt();
+
+        int lo=0, hi=(int)1e9+1;
+        while (lo+1<hi) {
+            int mid = lo+hi>>1;
+            if (pos(mid)) lo=mid;
+            else hi=mid;
+        }
+        System.out.println(lo);
+    }
+    
+}


### PR DESCRIPTION
## BOJ 14889 스타트와 링크
- 전형적인 조합만들기 문제
- n/2 명씩 두 팀을 만드는 모든 경우에 대해 답을 갱신해나가면 된다.
- 비트를 이용한 부분집합과 Integer.bitCount, ~ 비트반전으로 간단하게 구현가능

## BOJ 11725 트리의 부모 찾기
- 전형적인 트리에 대한 dfs문제
- dfs 인자로 직전방문한 노드=부모를 넘겨주면 visit 배열을 가질 필요가 없다

## BOJ 2805 나무 자르기
- 전형적인 parametric search 문제
- lo, hi 가 반대되는 boolean 값을 갖도록 설정하고 체크함수가 true면 lo, false면 hi로 지정함

## BOJ 2252 줄 세우기
- 전형적인 위상정렬 문제
- indegree를 줄이면서 우선순위큐에 indegree 0인 정점을 넣는 식으로 할 수 있고
- dfs로도 짤 수 있음.
  vsited 배열을 이용해 정점을 중복방문하지 않으면서 dfs를 수행하고
  콜 스택에서 빠져나올 때 해당 노드를 기록하면 위상정렬의 역순이 된다.