### PR TITLE
5주차

### DIFF
--- a/5주차/BOJ_1501_영어읽기_jbh.java
+++ b/5주차/BOJ_1501_영어읽기_jbh.java
@@ -1,0 +1,83 @@
+package week5;
+
+import java.util.*;
+import java.io.*;
+public class BOJ_1501_영어읽기_jbh {
+	static int n,m;
+	static HashMap<String,Integer> hm = new HashMap<>();
+	static StringBuilder result = new StringBuilder();
+	static void hmput(String s) {
+		if(s.length()==0)
+			return;
+		StringBuilder sb = new StringBuilder();
+		if(s.length()>=1)
+			sb.append(s.charAt(0));
+		if(s.length()>=3) {
+
+			String sub = s.substring(1, s.length()-1);
+			char[] ch = sub.toCharArray();
+			Arrays.sort(ch);
+			for(int i=0; i<ch.length; i++) {
+				sb.append(ch[i]);
+			}
+		}
+		if(s.length()>=2)
+			sb.append(s.charAt(s.length()-1));
+		
+		hm.put(sb.toString(), hm.getOrDefault(sb.toString(), 0)+1);
+		//System.out.println(sb.toString()+","+hm.get(sb.toString()));
+	}
+	static void print(String s) {
+		if(s.length() == 0) {
+			result.append(0+"\n");
+			return;
+		}
+		String[] sl = s.split(" ");
+		int temp  =1;
+		for(int i=0; i<sl.length; i++) {
+			StringBuilder sb = new StringBuilder();
+			s = sl[i];
+			if(s.length()==0) {
+				result.append(0+"\n");
+				return;
+			}
+			
+			if(s.length()>=1)
+				sb.append(s.charAt(0));
+			if(s.length()>=3) {
+
+				String sub = s.substring(1, s.length()-1);
+				char[] ch = sub.toCharArray();
+				Arrays.sort(ch);
+				for(int j=0; j<ch.length; j++) {
+					sb.append(ch[j]);
+				}
+			}
+			if(s.length()>=2)
+				sb.append(s.charAt(s.length()-1));
+			temp *= hm.getOrDefault(sb.toString(), 0);
+		}
+		
+		
+		result.append(temp+"\n");
+		
+	}
+	
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		for(int i=0; i<n; i++) {
+			String s= br.readLine();
+			hmput(s);
+		}
+		m = Integer.parseInt(br.readLine());
+		for(int i=0; i<m; i++) {
+			String s= br.readLine();
+			print(s);
+		}
+		System.out.println(result.toString());
+	}
+
+}
+

--- a/5주차/BOJ_16437_양구출작전_jbh.java
+++ b/5주차/BOJ_16437_양구출작전_jbh.java
@@ -1,0 +1,36 @@
+package week5;
+import java.util.*;
+import java.io.*;
+public class BOJ_16437_양구출작전_jbh {
+	static int n;
+	static boolean[] isSheep;
+	static int[] amount;
+	static ArrayList<ArrayList<Integer>> al = new ArrayList<ArrayList<Integer>>();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		n = Integer.parseInt(br.readLine());
+		isSheep = new boolean[n+1]; amount = new int[n+1];
+		for(int i=0; i<=n+1; i++)
+			al.add(new ArrayList<Integer>());
+		for(int i=2; i<=n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			if(st.nextToken().equals("S"))
+				isSheep[i] = true;
+			amount[i] = Integer.parseInt(st.nextToken());
+			int next = Integer.parseInt(st.nextToken());
+			al.get(next).add(i);
+			
+		}
+		System.out.println(dfs(1));
+	}
+	static long dfs(int now) {
+		long sum = 0;
+		for(int i=0; i<al.get(now).size(); i++) {
+			sum += dfs(al.get(now).get(i));
+		}
+		sum += isSheep[now] ? amount[now] : amount[now] * -1;
+		return (sum >=0) ? sum : 0;
+	}
+	
+}

--- a/5주차/BOJ_19238_스타트택시_jbh.java
+++ b/5주차/BOJ_19238_스타트택시_jbh.java
@@ -1,0 +1,157 @@
+package week5;
+
+
+import java.util.*;
+import java.io.*;
+
+public class BOJ_19238_Ω∫≈∏∆Æ≈√Ω√_jbh {
+	static int n,m,fuel;
+	static int[][] map;
+	static int sx,sy;
+	static int[] dx = {-1,1,0,0};
+	static int[] dy = {0,0,-1,1};
+	static HashMap<Integer,Integer> hm = new HashMap<>();
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		fuel = Integer.parseInt(st.nextToken());
+		map = new int[n][n];
+		for(int i=0; i<n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<n; j++)
+				map[i][j] = Integer.parseInt(st.nextToken());
+		}
+		st = new StringTokenizer(br.readLine());
+		sx = Integer.parseInt(st.nextToken())-1; sy = Integer.parseInt(st.nextToken())-1;
+		for(int i=0; i<m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken())-1;
+			int b = Integer.parseInt(st.nextToken())-1;
+			int c = Integer.parseInt(st.nextToken())-1;
+			int d = Integer.parseInt(st.nextToken())-1;
+			map[a][b] = 2;
+			hm.put(a*n+b, c*n+d);
+		}
+		while(m > 0) {
+		//	System.out.println(fuel);
+//			if(findClient() && moveDestination())
+//				m--;
+			if(findClient() && moveDestination()) {
+					m--;
+			}
+			else
+				break;
+		}
+		int result = -1;
+		if(m == 0)
+			result = fuel;
+		else
+			result = -1;
+		System.out.println(result);
+	}
+	
+	static boolean findClient() {
+		Queue<xy> q = new LinkedList<>();
+		boolean[][] visited = new boolean[n][n];
+		q.offer(new xy(sx,sy));
+		visited[sx][sy] =true;
+		int dist = 0;
+		PriorityQueue<xy> pq = new PriorityQueue<>();
+		while(!q.isEmpty()) {
+			int qsize = q.size();
+			if(dist > fuel)
+				return false;
+			for(int i=0; i<qsize; i++) {
+				xy now = q.poll();
+				int x = now.x; int y = now.y;
+				if(map[x][y] == 2)
+					pq.add(now);
+				for(int j=0; j<4; j++) {
+					int nx = x+dx[j]; int ny = y+dy[j];
+					if(nx<0 || ny<0 || nx>=n || ny>=n)
+						continue;
+					if(map[nx][ny] != 1 && !visited[nx][ny]) {
+						visited[nx][ny] = true;
+						q.offer(new xy(nx,ny));
+					}
+				}
+			}
+			
+			if(!pq.isEmpty()) {
+		//		System.out.println("pqsize :" + pq.size());
+				break;
+			}
+			dist +=1;
+		}
+		if(!pq.isEmpty()) {
+			xy now = pq.poll();
+			map[now.x][now.y] = 0;
+	//		System.out.println("º’¥‘ m : " + now.x+","+now.y);
+			sx = now.x; sy = now.y;
+			fuel -= dist;
+	//		System.out.println("dist :" + dist);
+			return true;
+		} else
+			return false;
+		
+	}
+	static boolean moveDestination() {
+		int tplace = hm.get(sx*n+sy);
+		int tx = tplace/n; int ty = tplace%n;
+		Queue<xy> q  = new LinkedList<>();
+		boolean[][] visited = new boolean[n][n];
+		q.add(new xy(sx,sy));
+		visited[sx][sy] = true;
+		int dist = 0;
+		while(!q.isEmpty()) {
+			int qsize = q.size();
+			if(fuel < dist)
+				return false;
+			
+			for(int i=0; i<qsize; i++) {
+				xy now = q.poll();
+				int x = now.x; int y = now.y;
+				if(x==tx && y == ty) {
+					fuel += dist;
+					sx = x; sy =y;
+	//				System.out.println("µµ¬¯ : " +x+","+y);
+					return true;
+				}
+				for(int j=0; j<4; j++) {
+					int nx = x+dx[j]; int ny =y+dy[j];
+					if(nx<0 || ny<0 || nx>=n || ny>=n)
+						continue;
+					if(map[nx][ny] != 1 && !visited[nx][ny]) {
+						visited[nx][ny] = true;
+						q.add(new xy(nx,ny));
+						
+					}
+				}
+			}
+			dist +=1;
+		}
+		
+		
+		return false;
+	}
+	
+	static class xy implements Comparable<xy>{
+		int x;
+		int y;
+
+		public xy(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		@Override
+		public int compareTo(xy o) {
+			if(this.x == o.x)
+				return this.y-o.y;
+			return this.x-o.y;
+		}
+	}
+}

--- a/5주차/BOJ_22234_가희와은행_jbh.java
+++ b/5주차/BOJ_22234_가희와은행_jbh.java
@@ -1,0 +1,90 @@
+package week5;
+import java.util.*;
+import java.io.*;
+public class BOJ_22234_°¡Èñ¿ÍÀºÇà_jbh {
+	static int n,t,w,m;
+	static PriorityQueue<xyd> pq = new PriorityQueue<>();
+	static StringBuilder sb = new StringBuilder();
+	static int time = 0;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n =  Integer.parseInt(st.nextToken());
+		t =  Integer.parseInt(st.nextToken());
+		w =  Integer.parseInt(st.nextToken());
+		Queue<xy> q = new LinkedList<>();
+		for(int i=0; i<n; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			q.add(new xy(a,b));
+		}
+		m = Integer.parseInt(br.readLine());
+		for(int i=0; i<m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			pq.add(new xyd(a,b,c));
+		}
+		Loop1 :
+		while(!q.isEmpty()) {
+			xy now = q.poll();
+			int np = now.x; int nt = now.y;
+		//	System.out.println(np+","+nt);
+			if(nt <=t) {
+				for(int i=0; i<nt; i++) {
+					time +=1;
+					sb.append(np+"\n");
+					if(time >= w)
+						break Loop1;
+				}
+					
+				while(!pq.isEmpty() && pq.peek().d <=time) {
+					xyd xyd = pq.poll();
+					q.add(new xy(xyd.x,xyd.y));
+				}
+			} else {
+				for(int i=0; i<t; i++) {
+					time +=1;
+					sb.append(np+"\n");
+					if(time >= w)
+						break Loop1;
+				}
+					
+				while(!pq.isEmpty() && pq.peek().d <=time) {
+					xyd xyd = pq.poll();
+					q.add(new xy(xyd.x,xyd.y));
+				}
+				q.add(new xy(np,nt-t));
+			}
+		}
+		
+		
+		System.out.println(sb.toString());
+	}
+	
+	static class xy {
+		int x;
+		int y;
+
+		public xy(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+	}
+	static class xyd implements Comparable<xyd>{
+		int x;
+		int y;
+		int d;
+		public xyd(int x, int y,int d) {
+			this.x = x;
+			this.y = y;
+			this.d = d;
+		}
+		@Override
+		public int compareTo(xyd o) {
+			return this.d - o.d;
+		}
+	}
+}

--- a/5주차/BOJ_22860_폴더정리_jbh.java
+++ b/5주차/BOJ_22860_폴더정리_jbh.java
@@ -1,0 +1,110 @@
+package week5;
+
+import java.util.*;
+import java.io.*;
+public class BOJ_22860_폴더정리_jbh {
+
+   static int n,m;
+   static int cnt = 2;
+   static int r1,r2;
+   static ArrayList<ArrayList<Integer>> al = new ArrayList<ArrayList<Integer>>();
+   static boolean[] isFolder;
+   static HashMap<Integer,String> his = new HashMap<>();
+   static HashMap<String,Integer> hsi = new HashMap<>();
+   static HashSet<String> hs = new HashSet<>();
+   public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+         StringTokenizer st = new StringTokenizer(br.readLine());
+         StringBuilder sb = new StringBuilder();
+         
+         for(int i=0; i<=10000; i++)
+            al.add(new ArrayList<Integer>());
+         n = Integer.parseInt(st.nextToken());
+         m = Integer.parseInt(st.nextToken());
+         
+         isFolder = new boolean[10000];
+         his.put(1, "main");
+         hsi.put("main", 1);
+         
+         
+         for(int i=0; i<n+m; i++) {
+            st = new StringTokenizer(br.readLine());
+            String parent = st.nextToken();
+            String child = st.nextToken();
+            int pnum = 0; int cnum = 0;
+            int num = st.nextToken().charAt(0)-'0';
+            //main이 시작이 아닐 때
+            //Folder는 유일하다
+       //     System.out.println(hsi.containsKey("FolderA"));
+            if(hsi.containsKey(parent)) {
+            	 pnum = hsi.get(parent);
+            }
+            else {
+            	pnum = cnt;
+            	his.put(cnt,parent);
+            	hsi.put(parent,cnt);
+            	cnt++;
+            }
+            
+          
+            
+            if(hsi.containsKey(child)) {
+                cnum = hsi.get(child);
+            }
+            else if(num == 1 ) {
+            	cnum = cnt;
+            	his.put(cnt,child);
+            	hsi.put(child,cnt);
+            	cnt++;
+            }
+            else {
+               cnum = cnt;
+               his.put(cnt, child);
+               
+               cnt++;
+            }
+//               cnum = cnt;
+//               his.put(cnt, child);
+//               hsi.put(child, cnt++);
+//            
+            
+            if(num == 1)
+            	isFolder[cnum] = true;
+            al.get(pnum).add(cnum);
+            
+            
+            
+            
+         }
+      //   System.out.println(hsi);
+      //   System.out.println(his);
+         int q = Integer.parseInt(br.readLine());
+         
+         for(int i=0; i<q; i++) {
+        	hs.clear(); r1= 0; r2 = 0;
+            String[] sl =br.readLine().split("/");
+            String s = sl[sl.length-1];
+            int now = hsi.get(s);
+       //     System.out.println(now);
+            dfs(now);
+            r1 = hs.size();
+            sb.append(r1+" "+r2+"\n");
+         }
+        // System.out.println("--");
+         System.out.println(sb.toString());
+   }
+   static void dfs(int now) {
+	   for(int i=0; i<al.get(now).size(); i++) {
+		   int next = al.get(now).get(i);
+		   if(isFolder[next]) {
+			   dfs(next);
+		   } else {
+			   hs.add(his.get(next));
+			   r2++;
+		   }
+		   
+	   }
+	   
+   }
+
+}

--- a/5주차/BOJ_25240_가희와파일탐색기2_jbh.java
+++ b/5주차/BOJ_25240_가희와파일탐색기2_jbh.java
@@ -1,0 +1,62 @@
+package week5;
+import java.util.*;
+import java.io.*;
+public class BOJ_25240_가희와파일탐색기2_jbh {
+
+	static int u,f;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		HashSet<String> isExist = new HashSet<String>();
+		u = Integer.parseInt(st.nextToken());
+		f = Integer.parseInt(st.nextToken());
+		HashMap<String,HashSet<String>> group = new HashMap<String,HashSet<String>>();
+		HashMap<String,List<String>> file = new HashMap<String,List<String>>();
+		
+		for(int i=0; i<u; i++) {
+			HashSet<String> s = new HashSet<>();
+			st = new StringTokenizer(br.readLine(),", ");
+			String name = st.nextToken();
+			while(st.hasMoreTokens()) {
+				s.add(st.nextToken());
+			}
+			s.add(name);
+			group.put(name, s);
+		}
+		for(int i=0; i<f; i++) {
+			List<String> ls = new ArrayList<String>();
+			st = new StringTokenizer(br.readLine());
+			String gname = st.nextToken();
+			for(int a=0; a<3; a++)
+				ls.add(st.nextToken());
+			file.put(gname, ls);
+		}
+		int q = Integer.parseInt(br.readLine());
+		for(int i=0; i<q; i++) {
+			st = new StringTokenizer(br.readLine());
+			String username = st.nextToken();
+			String filename = st.nextToken();
+			char target = st.nextToken().charAt(0);
+			int permit = 0;
+			HashSet<String> ugp = group.get(username);
+			List<String> file_info = file.get(filename);
+			if(username.equals(file_info.get(1))) {
+				permit = file_info.get(0).charAt(0)-'0';
+			} else if(ugp.contains(file_info.get(2))) {
+				permit = file_info.get(0).charAt(1)-'0';
+			} else
+				permit = file_info.get(0).charAt(2)-'0';
+			if(target =='X') {
+				if(permit >0 && permit % 2 == 1)
+					sb.append(1+"\n");
+				else
+					sb.append(0+"\n");
+				
+			}
+			//r 읽기 w 수정 x 실행
+		}
+		
+	}
+
+}


### PR DESCRIPTION
### 필수문제
---
BOJ 16437 [양 구출 작전](https://www.acmicpc.net/problem/16437)
- 늑대는 양 한마리를 먹고 죽는다
- 노드를 중복해서 방문하면 무조건 시초
- 어떤 n번노드가 갖고 있는 양의 수: 자기 자식들의 양의 수의 총합 + 자신의 상태
- 자신이 양이면 양의 수가 증가,  늑대면 양의 수 감소
- dfs로 루트에서 자식들 상태 종합하기 => 탑다운으로 호출해서 밑에서부터 종합되어 올라옴 
----
BOJ 22234 [가희와 은행](https://www.acmicpc.net/problem/22234)
- 은행원 1명 : 결과 처리를 큐 1개로 처리
- 오픈 전 손님 : 미리 큐 , 오픈 후 손님 : 시간 되면 큐에 넣기
- 오픈 후 손님  도착 순으로 정렬
- 오픈 후 손님 시간 되면 큐에 넣기 + 응대 고객 다시 큐에 넣기 처리만 하면 끝
----
BOJ 22234 [가희와 파일탐색기2](https://www.acmicpc.net/problem/25240)
- hashmap의 value에 hashset과 list를 이용해 원하는 데이터 관리
- 유저 이름에 따라 유저의 소속 그룹 관리 (hashmap의 value : hashset)
- 유저 정보 : hashmap 안의 hashset으로 관리
- 유저 이름으로 관리하기 위해 hashmap 사용 
- 상위 권한부터 부합하는 지 체킹하면서 permit 검사하면 끝 

----
BOJ 22860 [폴더정리](https://www.acmicpc.net/problem/22860)
- 트리구조 , 폴더는 유일 + 자식 가능, 파일은 중복 가능 +자식 불가
- 모두 string으로 되어있기에 int로 바꾸는 작업 시행,hashset으로 string to int, int to string 관리
- 폴더는 고유의 int번호를 가짐,  파일은 중복허용하여 int 번호 가짐 
- 메인 에서부터 연결 x, 이미 저장된 폴더 인지를 통해 연결해줘야함
- 연결 관계는 자식들의 파일 개수만 세기 때문에 자식만 연결
- 쿼리 마지막 폴더의 자식 중 파일 만나면 중복허용 x=> hashset, 중복허용 o=> 그냥 cnt
- 폴더 만나면 dfs


---
### 선택문제

BOJ 19238 [스타트 택시](https://www.acmicpc.net/problem/19238)
-  승객 찾기 BFS  이후 택시 이동
- 목적지 hashmap으로 위치 관리 (배열에 저장하면 중복된 목적지 때문에 지워짐 + hashmap 그냥 편함)
- 목적지까지 거리 bfs (벽 있어서 bfs 돌려야함)
-  태운 승객 수 = 목표 승객 수 까지 반복 
-  규칙맞게 bfs돌리면댐 , bfs Queue안에서 qsize 가지고 돌리면 구현 쉬워짐
----
BOJ 1501 [영어 읽기](https://www.acmicpc.net/problem/1501)
-  단어 = 앞뒤 때고 중간 소팅해서 다시 앞뒤 붙인 값
-  해석 대상이 "단어"가 아니고 "문장" => 각 단어의 경우의 수에 대한 누적 곱