### PR TITLE
5주차

### DIFF
--- a/5주차/BOJ_16437_양구출작전_maiego.java
+++ b/5주차/BOJ_16437_양구출작전_maiego.java
@@ -1,0 +1,35 @@
+import java.util.*;
+
+public class Main {
+	static int[] sheep, wolf;
+	static List<Integer> adj[];
+	
+	static long dfs(int u) {
+		long ret = 0;
+		for (int v: adj[u])
+			ret += dfs(v);
+		return sheep[u] + Math.max(0, ret-wolf[u]);
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		sheep = new int[n+1];
+		wolf = new int[n+1];
+		
+		adj = new List[n+1];
+		for (int i=1; i<=n; ++i)
+			adj[i] = new ArrayList<>();
+
+		for (int i=2; i<=n; ++i) {
+			if (sc.next().equals("S"))
+				sheep[i] = sc.nextInt();
+			else wolf[i] = sc.nextInt();
+			int j = sc.nextInt();
+			adj[j].add(i);
+		}
+		System.out.println(dfs(1));
+
+	}
+
+}

--- a/5주차/BOJ_22234_가희와은행_maiego.java
+++ b/5주차/BOJ_22234_가희와은행_maiego.java
@@ -1,0 +1,52 @@
+import java.util.*;
+
+public class Main {
+	static class Item {
+		int id, remain;
+		Item(int a, int b) {
+			id=a; remain=b;
+		}
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		StringBuilder sb = new StringBuilder();
+
+		int n = sc.nextInt();
+		int t = sc.nextInt();
+		int w = sc.nextInt();
+
+		Deque<Item> q = new ArrayDeque<>();
+		for (int i=0; i<n; ++i)
+			q.add(new Item(sc.nextInt(), sc.nextInt()));
+
+		int m = sc.nextInt();
+		Map<Integer, Item> incoming = new HashMap<>();
+		while (m-->0) {
+			int id = sc.nextInt();
+			int remain = sc.nextInt();
+			int time = sc.nextInt();
+			Item item = new Item(id, remain);
+			incoming.put(time, item);
+		}
+		
+		Item cur = null;
+		int consume = 0;
+		for (int time=0; time<w; ++time) {
+			Item x = incoming.get(time);
+			if (x!=null) q.add(x);
+			
+			if (consume==0) {
+				if (cur!=null && cur.remain > 0)
+					q.add(cur);
+				cur = q.pop();
+				consume = Math.min(t, cur.remain);
+			}
+
+			sb.append(cur.id).append('\n');
+			--consume; --cur.remain;
+		}
+		
+		System.out.println(sb);
+	}
+}

--- a/5주차/BOJ_22860_폴더정리_maiego.java
+++ b/5주차/BOJ_22860_폴더정리_maiego.java
@@ -1,0 +1,81 @@
+import java.util.*;
+
+public class Main {
+	static Map<String,Integer> name2id;
+	static String[] id2name;
+	static int[] kindCnt, fileCnt;
+	static Set<String>[] fileSet;
+	
+	static List<Integer> adj[];
+	
+	static void dfs(int u) {
+		for (int v: adj[u]) {
+			dfs(v);
+			for (String s: fileSet[v])
+				fileSet[u].add(s);
+			fileCnt[u] += fileCnt[v];
+		}
+		kindCnt[u] = fileSet[u].size();
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		StringBuilder sb = new StringBuilder();
+		
+		int dirN = sc.nextInt();
+		int fileN = sc.nextInt();
+
+		id2name = new String[dirN+1];
+		id2name[0] = "main";
+		name2id = new HashMap<>();
+		name2id.put("main", 0);
+		
+		kindCnt = new int[dirN+1];
+		fileCnt = new int[dirN+1];
+		fileSet = new TreeSet[dirN+1];
+		for (int i=0; i<=dirN; ++i)
+			fileSet[i] = new TreeSet<>();
+		
+		int cur=0;
+		
+		adj = new List[dirN+1];
+		for (int i=0; i<=dirN; ++i)
+			adj[i] = new ArrayList<>();
+
+		for (int i=0; i<dirN+fileN; ++i) {
+			String p = sc.next();
+			String s = sc.next();
+			if (name2id.get(p)==null) {
+				name2id.put(p, ++cur);
+				id2name[cur]=p;
+			}
+			int pid = name2id.get(p);
+			if (sc.nextInt()==1) {
+				if (name2id.get(s)==null) {
+					name2id.put(s, ++cur);
+					id2name[cur]=s;
+				}
+				adj[pid].add(name2id.get(s));
+			} else {
+				fileSet[pid].add(s);
+				fileCnt[pid]++;
+			}
+		}
+		
+		dfs(0);
+		
+		int q = sc.nextInt();
+		while (q-->0) {
+			String s = sc.next();
+			String[] path = s.split("/");
+			s = path[path.length-1];
+			
+			int idx = name2id.get(s);
+			sb.append(String.format("%d %d\n", kindCnt[idx], fileCnt[idx]));
+		}
+		
+		System.out.println(sb);
+
+	}
+
+}


### PR DESCRIPTION
## BOJ 16437 양 구출 작전
tree에 대한 dfs를 수행하여
자기섬에사는 양 수 + (자식섬에서 자기로 올라오는 양들의 합 - 자기섬에사는 늑대수)
를 각 노드마다 구하면 root(1번섬)의 값이 답이 된다.
입력을 제외하면 시간복잡도는 O(섬 수)

## BOJ 22234 가희와 은행
고객 정보는 id와 필요시간으로 나타낼 수 있고
대기큐를 하나 만들고
이후에 들어오는 고객은 해시맵으로 들어오는 시간을 key로 하고 고객정보(id, 필요시간)를 value로 저장한다.
time 0부터 w-1 까지 시뮬레이션을 하면 된다.
입력을 제외하면 시간복잡도는 O(w)

## BOJ 22860 폴더정리
폴더들만으로 트리를 구성하고 파일은 입력될 때 바로 부모폴더의 값을 갱신한다
트리순회를 편하게 하기위해 name2id과 id2name을 만들고 int값으로 트리를 만든다.
트리에 대한 dfs를 수행하면서 폴더 하위의 파일의 종류와 개수를 구한다.
파일의 종류 = (현재폴더의 파일 set과 각 자식노드 하위의 파일 set의 합집합)의 size
파일의 수 = 현재노드의 파일 수 + 자식노드들의 파일 수
시간복잡도는 O(폴더 수 + 파일수)